### PR TITLE
feat: enhance top navigation bar

### DIFF
--- a/components/navigation/mobile-nav.tsx
+++ b/components/navigation/mobile-nav.tsx
@@ -6,13 +6,7 @@ import { createClient } from "@/lib/supabase/client"
 import { useEffect, useState } from "react"
 import type { User } from "@supabase/supabase-js"
 
-const navItems = [
-  { href: "/", label: "總覽", emoji: "📊" },
-  { href: "/debts", label: "債務", emoji: "💳" },
-  { href: "/progress", label: "進度", emoji: "📈" },
-  { href: "/strategy", label: "策略", emoji: "🎯" },
-  { href: "/tools", label: "工具", emoji: "🛠️" },
-]
+import { navItems } from "./nav-items"
 
 export function MobileNav() {
   const pathname = usePathname()
@@ -45,24 +39,27 @@ export function MobileNav() {
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-50 glass border-t border-white/20 px-4 py-2 md:hidden">
       <div className="flex items-center justify-around">
-        {navItems.map((item) => {
-          const isActive = pathname === item.href
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={cn(
-                "flex flex-col items-center gap-1 px-3 py-2 rounded-xl transition-all duration-200",
-                isActive
-                  ? "bg-gradient-to-r from-purple-600 to-blue-600 text-white scale-110"
-                  : "text-muted-foreground hover:text-foreground hover:scale-105",
-              )}
-            >
-              <span className="text-lg">{item.emoji}</span>
-              <span className="text-xs font-medium">{item.label}</span>
-            </Link>
-          )
-        })}
+        {navItems
+          .filter((item) => !item.hiddenOnMobile)
+          .map((item) => {
+            const isActive =
+              item.href === "/" ? pathname === "/" : pathname.startsWith(item.href)
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  "flex flex-col items-center gap-1 px-3 py-2 rounded-xl transition-all duration-200",
+                  isActive
+                    ? "bg-gradient-to-r from-purple-600 to-blue-600 text-white scale-110"
+                    : "text-muted-foreground hover:text-foreground hover:scale-105",
+                )}
+              >
+                <span className="text-lg">{item.emoji}</span>
+                <span className="text-xs font-medium">{item.label}</span>
+              </Link>
+            )
+          })}
       </div>
     </nav>
   )

--- a/components/navigation/nav-items.ts
+++ b/components/navigation/nav-items.ts
@@ -1,0 +1,72 @@
+import type { LucideIcon } from "lucide-react"
+import {
+  BarChart3,
+  CreditCard,
+  LayoutDashboard,
+  Target,
+  TrendingUp,
+  Wrench,
+} from "lucide-react"
+
+export type NavBadgeVariant = "default" | "secondary" | "destructive" | "outline"
+
+export interface AppNavItem {
+  href: string
+  label: string
+  description: string
+  icon: LucideIcon
+  emoji: string
+  badge?: {
+    label: string
+    variant?: NavBadgeVariant
+  }
+  hiddenOnMobile?: boolean
+}
+
+export const navItems: AppNavItem[] = [
+  {
+    href: "/",
+    label: "總覽",
+    description: "掌握財務概況",
+    icon: LayoutDashboard,
+    emoji: "📊",
+  },
+  {
+    href: "/debts",
+    label: "債務",
+    description: "管理所有債務帳戶",
+    icon: CreditCard,
+    emoji: "💳",
+  },
+  {
+    href: "/progress",
+    label: "進度",
+    description: "追蹤還款進度",
+    icon: TrendingUp,
+    emoji: "📈",
+  },
+  {
+    href: "/strategy",
+    label: "策略",
+    description: "規劃還款方案",
+    icon: Target,
+    emoji: "🎯",
+  },
+  {
+    href: "/reports",
+    label: "報表",
+    description: "分析財務趨勢",
+    icon: BarChart3,
+    emoji: "📑",
+    badge: { label: "新功能", variant: "secondary" },
+    hiddenOnMobile: true,
+  },
+  {
+    href: "/tools",
+    label: "工具",
+    description: "AI 輔助決策",
+    icon: Wrench,
+    emoji: "🛠️",
+    badge: { label: "AI", variant: "outline" },
+  },
+]

--- a/components/navigation/top-nav.tsx
+++ b/components/navigation/top-nav.tsx
@@ -1,15 +1,28 @@
 "use client"
 
 import Link from "next/link"
+import { usePathname } from "next/navigation"
 import { Bell } from "lucide-react"
+
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import {
+  NavigationMenu,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+} from "@/components/ui/navigation-menu"
+import { cn } from "@/lib/utils"
 import { UserProfile } from "@/components/auth/user-profile"
 
+import { navItems } from "./nav-items"
+
 export function TopNav() {
+  const pathname = usePathname()
+
   return (
-    <header className="sticky top-0 z-40 glass border-b border-white/20 px-4 py-3">
-      <div className="flex items-center justify-between max-w-7xl mx-auto">
+    <header className="sticky top-0 z-40 glass border-b border-white/20 px-4 py-3 backdrop-blur-lg">
+      <div className="max-w-7xl mx-auto flex items-center gap-4">
         {/* Brand Logo */}
         <Link
           href="/"
@@ -19,15 +32,70 @@ export function TopNav() {
           <div className="w-10 h-10 rounded-full bg-gradient-to-r from-purple-600 to-blue-600 flex items-center justify-center transition-transform duration-150 group-hover:scale-105">
             <span className="text-white font-bold text-lg">💰</span>
           </div>
-          <div>
+          <div className="hidden sm:block">
             <h1 className="font-bold text-lg gradient-text">DebtWise AI</h1>
             <p className="text-xs text-muted-foreground">智慧債務管理</p>
           </div>
         </Link>
 
+        {/* Navigation */}
+        <NavigationMenu className="hidden md:flex flex-1 justify-center">
+          <NavigationMenuList className="glass rounded-full border border-white/15 bg-white/5 px-1 py-1">
+            {navItems.map((item) => {
+              const isActive =
+                item.href === "/" ? pathname === "/" : pathname.startsWith(item.href)
+              const Icon = item.icon
+              const badge = item.badge
+
+              return (
+                <NavigationMenuItem key={item.href}>
+                  <NavigationMenuLink
+                    asChild
+                    active={isActive}
+                    className={cn(
+                      "flex items-center gap-3 rounded-full px-4 py-2 text-sm font-medium text-white/70 transition-all duration-200",
+                      "focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
+                      isActive
+                        ? "bg-white/20 text-white shadow-lg shadow-purple-500/20"
+                        : "hover:bg-white/10 hover:text-white",
+                    )}
+                  >
+                    <Link href={item.href} aria-current={isActive ? "page" : undefined}>
+                      <div className="flex items-center gap-2">
+                        <span className="flex h-8 w-8 items-center justify-center rounded-full bg-white/10 text-white">
+                          <Icon className="h-4 w-4" />
+                        </span>
+                        <div className="flex flex-col text-left">
+                          <span className="leading-tight">{item.label}</span>
+                          <span className="text-[11px] text-white/60 hidden xl:block">
+                            {item.description}
+                          </span>
+                        </div>
+                        {badge ? (
+                          <Badge
+                            variant={badge.variant}
+                            className="ml-1 hidden lg:inline-flex border-white/30 bg-white/15 text-[10px] uppercase tracking-wide text-white/90"
+                          >
+                            {badge.label}
+                          </Badge>
+                        ) : null}
+                      </div>
+                    </Link>
+                  </NavigationMenuLink>
+                </NavigationMenuItem>
+              )
+            })}
+          </NavigationMenuList>
+        </NavigationMenu>
+
         {/* User Actions */}
-        <div className="flex items-center gap-3">
-          <Button variant="ghost" size="icon" className="relative">
+        <div className="flex items-center gap-3 ml-auto">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="relative text-white hover:bg-white/10 hover:text-white"
+            aria-label="查看通知"
+          >
             <Bell className="h-5 w-5" />
             <Badge className="absolute -top-1 -right-1 h-5 w-5 flex items-center justify-center p-0 bg-gradient-to-r from-orange-400 to-yellow-400 text-xs">
               3


### PR DESCRIPTION
## Summary
- add a shared navigation config with metadata for desktop and mobile menus
- build a desktop top navigation experience with icons, active states, and badges
- update the mobile nav to consume the shared config and improve active state detection

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4eed8edd0832ea353f4bc27c293e1