### PR TITLE
Improve dashboard contrast and theme defaults

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -41,39 +41,42 @@ export default function DashboardPage() {
     <ProtectedRoute>
       <div className="min-h-[calc(100vh-5rem)] pb-24 md:pb-12">
         <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4">
-          <section className="flex flex-col justify-between gap-4 pt-4 md:flex-row md:items-center">
-            <div className="space-y-3">
-              <div className="flex flex-wrap items-center gap-2 text-xs text-white/60">
-                <Badge variant="outline" className="border-indigo-400/40 bg-indigo-500/10 text-indigo-200">
-                  <ShieldCheck className="mr-1 h-3.5 w-3.5" /> 智慧守護
-                </Badge>
-                <span>最後更新：{lastUpdatedLabel}</span>
+          <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 p-6 shadow-xl shadow-indigo-500/10">
+            <div className="flex flex-col justify-between gap-6 md:flex-row md:items-center">
+              <div className="space-y-3 text-slate-100">
+                <div className="flex flex-wrap items-center gap-2 text-xs text-slate-300">
+                  <Badge variant="outline" className="border-indigo-400/40 bg-indigo-500/20 text-indigo-100">
+                    <ShieldCheck className="mr-1 h-3.5 w-3.5" /> 智慧守護
+                  </Badge>
+                  <span className="font-medium text-slate-200">最後更新：{lastUpdatedLabel}</span>
+                </div>
+                <div className="space-y-2">
+                  <h1 className="text-3xl font-semibold tracking-tight md:text-4xl">財務健康儀表板</h1>
+                  <p className="max-w-2xl text-sm text-slate-200 md:text-base">
+                    透過 AI 智能整合，即時掌握債務狀況、還款進度與風險預警，打造專屬於你的財務策略。
+                  </p>
+                </div>
               </div>
-              <div className="space-y-2">
-                <h1 className="text-3xl font-semibold tracking-tight text-white md:text-4xl">財務健康儀表板</h1>
-                <p className="max-w-2xl text-sm text-white/70 md:text-base">
-                  透過 AI 智能整合，即時掌握債務狀況、還款進度與風險預警，打造專屬於你的財務策略。
-                </p>
+              <div className="flex flex-col gap-2 text-slate-100 sm:flex-row sm:items-center">
+                <Button
+                  variant="outline"
+                  className="border-slate-300/30 bg-slate-900/60 text-slate-100 backdrop-blur hover:bg-slate-900/80"
+                  onClick={() => refresh()}
+                  disabled={isRefreshing || isBusy}
+                >
+                  <RefreshCcw className={`mr-2 h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
+                  {isRefreshing ? "刷新中" : "重新整理"}
+                </Button>
+                <Button className="bg-gradient-to-r from-indigo-500 via-purple-500 to-sky-500 text-slate-50 shadow-lg shadow-indigo-500/30 hover:from-indigo-400 hover:via-purple-400 hover:to-sky-400">
+                  <Sparkles className="mr-2 h-4 w-4" /> 產生 AI 洞察
+                </Button>
               </div>
             </div>
-            <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                className="border-white/20 bg-white/10 text-white hover:bg-white/20"
-                onClick={() => refresh()}
-                disabled={isRefreshing || isBusy}
-              >
-                <RefreshCcw className={`mr-2 h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
-                {isRefreshing ? "刷新中" : "重新整理"}
-              </Button>
-              <Button className="bg-gradient-to-r from-indigo-500 via-purple-500 to-sky-500 text-white shadow-lg shadow-indigo-500/30 hover:from-indigo-400 hover:via-purple-400 hover:to-sky-400">
-                <Sparkles className="mr-2 h-4 w-4" /> 產生 AI 洞察
-              </Button>
-            </div>
+            <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.22),_transparent_65%)]" />
           </section>
 
           {error ? (
-            <Alert className="border-rose-500/30 bg-rose-500/10 text-rose-100">
+            <Alert className="border-rose-400/60 bg-rose-500/20 text-rose-50">
               <AlertTitle>資料載入失敗</AlertTitle>
               <AlertDescription>{error}</AlertDescription>
             </Alert>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,11 +29,13 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="zh-TW">
-      <body className={`${inter.variable} ${jetbrainsMono.variable} bg-slate-950 font-sans antialiased text-white`}>
+    <html lang="zh-TW" className="dark">
+      <body
+        className={`${inter.variable} ${jetbrainsMono.variable} bg-background font-sans antialiased text-foreground`}
+      >
         <TopNav notificationCount={0} />
         <Suspense fallback={null}>
-          <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.12),_transparent_55%)] pt-20">
+          <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.18),_transparent_60%)] pt-20">
             {children}
           </div>
           <GlobalAddDebtDialog />


### PR DESCRIPTION
## Summary
- enable the global dark theme token usage by default and rely on background/foreground variables
- refresh the dashboard hero section with a high-contrast container and updated action styles
- adjust dashboard error alert colors for better readability against the dark surface

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d534d6876c832e93d509379d6e5706