### PR TITLE
Improve dashboard and form contrast

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -41,39 +41,41 @@ export default function DashboardPage() {
     <ProtectedRoute>
       <div className="min-h-[calc(100vh-5rem)] pb-24 md:pb-12">
         <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4">
-          <section className="flex flex-col justify-between gap-4 pt-4 md:flex-row md:items-center">
-            <div className="space-y-3">
-              <div className="flex flex-wrap items-center gap-2 text-xs text-white/60">
-                <Badge variant="outline" className="border-indigo-400/40 bg-indigo-500/10 text-indigo-200">
-                  <ShieldCheck className="mr-1 h-3.5 w-3.5" /> 智慧守護
-                </Badge>
-                <span>最後更新：{lastUpdatedLabel}</span>
+          <section className="relative overflow-hidden rounded-3xl border border-gray-200 bg-white p-6 shadow-xl">
+            <div className="flex flex-col justify-between gap-6 md:flex-row md:items-center">
+              <div className="space-y-3 text-[#111827]">
+                <div className="flex flex-wrap items-center gap-2 text-xs text-gray-600">
+                  <Badge variant="outline" className="border-indigo-200 bg-indigo-50 text-indigo-600">
+                    <ShieldCheck className="mr-1 h-3.5 w-3.5" /> 智慧守護
+                  </Badge>
+                  <span className="font-medium text-gray-600">最後更新：{lastUpdatedLabel}</span>
+                </div>
+                <div className="space-y-2">
+                  <h1 className="text-3xl font-semibold tracking-tight text-[#111827] md:text-4xl">財務健康儀表板</h1>
+                  <p className="max-w-2xl text-sm text-gray-600 md:text-base">
+                    透過 AI 智能整合，即時掌握債務狀況、還款進度與風險預警，打造專屬於你的財務策略。
+                  </p>
+                </div>
               </div>
-              <div className="space-y-2">
-                <h1 className="text-3xl font-semibold tracking-tight text-white md:text-4xl">財務健康儀表板</h1>
-                <p className="max-w-2xl text-sm text-white/70 md:text-base">
-                  透過 AI 智能整合，即時掌握債務狀況、還款進度與風險預警，打造專屬於你的財務策略。
-                </p>
+              <div className="flex flex-col gap-2 text-[#111827] sm:flex-row sm:items-center">
+                <Button
+                  variant="outline"
+                  className="border-gray-300 bg-white text-[#111827] hover:bg-gray-50"
+                  onClick={() => refresh()}
+                  disabled={isRefreshing || isBusy}
+                >
+                  <RefreshCcw className={`mr-2 h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
+                  {isRefreshing ? "刷新中" : "重新整理"}
+                </Button>
+                <Button className="bg-indigo-600 text-white hover:bg-indigo-700">
+                  <Sparkles className="mr-2 h-4 w-4" /> 產生 AI 洞察
+                </Button>
               </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                className="border-white/20 bg-white/10 text-white hover:bg-white/20"
-                onClick={() => refresh()}
-                disabled={isRefreshing || isBusy}
-              >
-                <RefreshCcw className={`mr-2 h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
-                {isRefreshing ? "刷新中" : "重新整理"}
-              </Button>
-              <Button className="bg-gradient-to-r from-indigo-500 via-purple-500 to-sky-500 text-white shadow-lg shadow-indigo-500/30 hover:from-indigo-400 hover:via-purple-400 hover:to-sky-400">
-                <Sparkles className="mr-2 h-4 w-4" /> 產生 AI 洞察
-              </Button>
             </div>
           </section>
 
           {error ? (
-            <Alert className="border-rose-500/30 bg-rose-500/10 text-rose-100">
+            <Alert className="border-rose-400/60 bg-rose-500/20 text-rose-50">
               <AlertTitle>資料載入失敗</AlertTitle>
               <AlertDescription>{error}</AlertDescription>
             </Alert>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,11 +29,13 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="zh-TW">
-      <body className={`${inter.variable} ${jetbrainsMono.variable} bg-slate-950 font-sans antialiased text-white`}>
+    <html lang="zh-TW" className="dark">
+      <body
+        className={`${inter.variable} ${jetbrainsMono.variable} bg-background font-sans antialiased text-foreground`}
+      >
         <TopNav notificationCount={0} />
         <Suspense fallback={null}>
-          <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.12),_transparent_55%)] pt-20">
+          <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.18),_transparent_60%)] pt-20">
             {children}
           </div>
           <GlobalAddDebtDialog />

--- a/components/debts/add-debt-dialog.tsx
+++ b/components/debts/add-debt-dialog.tsx
@@ -76,7 +76,7 @@ export function AddDebtDialog({ open, onOpenChange, onSuccess }: AddDebtDialogPr
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[425px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>新增債務</DialogTitle>
+          <DialogTitle className="text-[#111827]">新增債務</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
@@ -86,6 +86,7 @@ export function AddDebtDialog({ open, onOpenChange, onSuccess }: AddDebtDialogPr
               value={formData.name}
               onChange={(e) => setFormData({ ...formData, name: e.target.value })}
               placeholder="例如：信用卡A"
+              className="placeholder:text-[#6B7280]"
               required
             />
           </div>
@@ -116,6 +117,7 @@ export function AddDebtDialog({ open, onOpenChange, onSuccess }: AddDebtDialogPr
                 value={formData.total_amount}
                 onChange={(e) => setFormData({ ...formData, total_amount: Number(e.target.value) })}
                 placeholder="0"
+                className="placeholder:text-[#6B7280]"
                 required
               />
             </div>
@@ -127,6 +129,7 @@ export function AddDebtDialog({ open, onOpenChange, onSuccess }: AddDebtDialogPr
                 value={formData.current_balance}
                 onChange={(e) => setFormData({ ...formData, current_balance: Number(e.target.value) })}
                 placeholder="0"
+                className="placeholder:text-[#6B7280]"
                 required
               />
             </div>
@@ -142,6 +145,7 @@ export function AddDebtDialog({ open, onOpenChange, onSuccess }: AddDebtDialogPr
                 value={formData.interest_rate}
                 onChange={(e) => setFormData({ ...formData, interest_rate: Number(e.target.value) })}
                 placeholder="0.00"
+                className="placeholder:text-[#6B7280]"
                 required
               />
             </div>
@@ -153,6 +157,7 @@ export function AddDebtDialog({ open, onOpenChange, onSuccess }: AddDebtDialogPr
                 value={formData.minimum_payment}
                 onChange={(e) => setFormData({ ...formData, minimum_payment: Number(e.target.value) })}
                 placeholder="0"
+                className="placeholder:text-[#6B7280]"
                 required
               />
             </div>
@@ -175,6 +180,7 @@ export function AddDebtDialog({ open, onOpenChange, onSuccess }: AddDebtDialogPr
               value={formData.description}
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
               placeholder="額外說明..."
+              className="placeholder:text-[#6B7280]"
               rows={3}
             />
           </div>
@@ -182,10 +188,15 @@ export function AddDebtDialog({ open, onOpenChange, onSuccess }: AddDebtDialogPr
           {error && <div className="text-red-500 text-sm bg-red-50 p-3 rounded-lg">{error}</div>}
 
           <div className="flex justify-end gap-3">
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            <Button
+              type="button"
+              variant="outline"
+              className="bg-gray-100 text-gray-700 hover:bg-gray-200"
+              onClick={() => onOpenChange(false)}
+            >
               取消
             </Button>
-            <Button type="submit" disabled={isLoading}>
+            <Button type="submit" className="bg-indigo-600 text-white hover:bg-indigo-700" disabled={isLoading}>
               {isLoading ? "建立中..." : "建立債務"}
             </Button>
           </div>

--- a/components/debts/add-debt-modal.tsx
+++ b/components/debts/add-debt-modal.tsx
@@ -131,8 +131,8 @@ export function AddDebtModal({ isOpen, onClose, onAdd }: AddDebtModalProps) {
     <Dialog open={isOpen} onOpenChange={handleDialogChange}>
       <DialogContent className="glass max-w-md mx-auto">
         <DialogHeader>
-          <DialogTitle className="flex items-center justify-between">
-            <span className="gradient-text">新增債務項目</span>
+          <DialogTitle className="flex items-center justify-between text-[#111827]">
+            <span className="font-semibold text-[#111827]">新增債務項目</span>
             <Button variant="ghost" size="icon" onClick={handleRequestClose} disabled={isSubmitting}>
               <X className="h-4 w-4" />
             </Button>
@@ -146,8 +146,8 @@ export function AddDebtModal({ isOpen, onClose, onAdd }: AddDebtModalProps) {
               id="debt-name"
               value={formData.name}
               onChange={(event) => handleInputChange("name", event.target.value)}
-              placeholder="例如：信用卡 A"
-              className="w-full focus:ring-purple-500"
+              placeholder="例如：信用卡A"
+              className="w-full focus:ring-purple-500 placeholder:text-[#6B7280]"
               disabled={isSubmitting}
               required
             />
@@ -183,7 +183,7 @@ export function AddDebtModal({ isOpen, onClose, onAdd }: AddDebtModalProps) {
               value={formData.total_amount ? String(formData.total_amount) : ""}
               onChange={(event) => handleNumberChange("total_amount", event.target.value)}
               placeholder="請輸入原始貸款金額"
-              className="w-full focus:ring-purple-500"
+              className="w-full focus:ring-purple-500 placeholder:text-[#6B7280]"
               disabled={isSubmitting}
             />
             <p className="text-xs text-gray-500">若未填寫，系統將以目前餘額作為原始金額。</p>
@@ -198,7 +198,7 @@ export function AddDebtModal({ isOpen, onClose, onAdd }: AddDebtModalProps) {
               value={formData.current_balance ? String(formData.current_balance) : ""}
               onChange={(event) => handleNumberChange("current_balance", event.target.value)}
               placeholder="請輸入目前尚未償還金額"
-              className="w-full focus:ring-purple-500"
+              className="w-full focus:ring-purple-500 placeholder:text-[#6B7280]"
               disabled={isSubmitting}
               required
             />
@@ -214,7 +214,7 @@ export function AddDebtModal({ isOpen, onClose, onAdd }: AddDebtModalProps) {
               value={formData.interest_rate ? String(formData.interest_rate) : ""}
               onChange={(event) => handleNumberChange("interest_rate", event.target.value)}
               placeholder="例如：3.5"
-              className="w-full focus:ring-purple-500"
+              className="w-full focus:ring-purple-500 placeholder:text-[#6B7280]"
               disabled={isSubmitting}
             />
           </div>
@@ -228,7 +228,7 @@ export function AddDebtModal({ isOpen, onClose, onAdd }: AddDebtModalProps) {
               value={formData.minimum_payment ? String(formData.minimum_payment) : ""}
               onChange={(event) => handleNumberChange("minimum_payment", event.target.value)}
               placeholder="請輸入每月最低還款額"
-              className="w-full focus:ring-purple-500"
+              className="w-full focus:ring-purple-500 placeholder:text-[#6B7280]"
               disabled={isSubmitting}
             />
           </div>
@@ -252,7 +252,7 @@ export function AddDebtModal({ isOpen, onClose, onAdd }: AddDebtModalProps) {
               value={formData.description ?? ""}
               onChange={(event) => handleInputChange("description", event.target.value)}
               placeholder="可紀錄債務來源、還款提醒等資訊"
-              className="w-full focus:ring-purple-500"
+              className="w-full focus:ring-purple-500 placeholder:text-[#6B7280]"
               disabled={isSubmitting}
               rows={3}
             />
@@ -260,7 +260,7 @@ export function AddDebtModal({ isOpen, onClose, onAdd }: AddDebtModalProps) {
 
           <Button
             type="submit"
-            className="w-full bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 hover:scale-105 transition-transform duration-200"
+            className="w-full bg-indigo-600 text-white hover:bg-indigo-700"
             disabled={isSubmitting}
           >
             {isSubmitting ? "新增中..." : "新增債務"}

--- a/components/payments/add-payment-dialog.tsx
+++ b/components/payments/add-payment-dialog.tsx
@@ -89,7 +89,7 @@ export function AddPaymentDialog({ open, onOpenChange, onSuccess }: AddPaymentDi
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
-          <DialogTitle>記錄還款</DialogTitle>
+          <DialogTitle className="text-[#111827]">記錄還款</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
@@ -116,6 +116,7 @@ export function AddPaymentDialog({ open, onOpenChange, onSuccess }: AddPaymentDi
               value={formData.amount}
               onChange={(e) => setFormData({ ...formData, amount: Number(e.target.value) })}
               placeholder="0"
+              className="placeholder:text-[#6B7280]"
               required
             />
           </div>
@@ -155,6 +156,7 @@ export function AddPaymentDialog({ open, onOpenChange, onSuccess }: AddPaymentDi
               value={formData.notes}
               onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
               placeholder="額外說明..."
+              className="placeholder:text-[#6B7280]"
               rows={3}
             />
           </div>
@@ -162,10 +164,19 @@ export function AddPaymentDialog({ open, onOpenChange, onSuccess }: AddPaymentDi
           {error && <div className="text-red-500 text-sm bg-red-50 p-3 rounded-lg">{error}</div>}
 
           <div className="flex justify-end gap-3">
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            <Button
+              type="button"
+              variant="outline"
+              className="bg-gray-100 text-gray-700 hover:bg-gray-200"
+              onClick={() => onOpenChange(false)}
+            >
               取消
             </Button>
-            <Button type="submit" disabled={isLoading || !formData.debt_id}>
+            <Button
+              type="submit"
+              className="bg-indigo-600 text-white hover:bg-indigo-700"
+              disabled={isLoading || !formData.debt_id}
+            >
               {isLoading ? "記錄中..." : "記錄還款"}
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- restyle the dashboard hero with a light surface and dark heading color for clarity
- standardize add-debt and add-payment form placeholders and primary/cancel button colors for accessible contrast
- align modal titles with the requested deep gray heading color

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d534d6876c832e93d509379d6e5706